### PR TITLE
Lein repl timeout

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,8 @@
                                                     :output-dir "target/classes/public/js/chat-demo"
                                                     :optimizations :none
                                                     :source-map true}}]}
-                   :repl-options {:init-ns user
+                   :repl-options {:timeout 120000
+                                  :init-ns user
                                   :init (start)
                                   :welcome (do
                                              (println "Welcome to the core.async tutorial!")

--- a/resources/templates/index.html
+++ b/resources/templates/index.html
@@ -31,7 +31,7 @@
                 <h2>Requirements</h2>
             </header>
             <p>
-                In order to complete this course, you will need this following:
+                In order to complete this course, you will need the following:
             </p>
             <ul>
                 <li>Familiarity with the Clojure/ClojureScript programming language</li>

--- a/resources/templates/reference/primitives.html
+++ b/resources/templates/reference/primitives.html
@@ -20,7 +20,7 @@
     The historical roots of core.async trace all the way back to Hoare’s <a href="http://usingcsp.com/">Communicating
     Sequential Processes</a> (CSP). One of the most immediate inspirations for core.async is the
     <a href="http://golang.org/">Go programming language</a>. Fundamentally, one of the principles behind CSP is
-    that coordination between concurrent processes is achieved via message-passing. In core.async, this achieved
+    that coordination between concurrent processes is achieved via message-passing. In core.async, this is achieved
     through the use of queue-like <em>channels</em>.
 </p>
 
@@ -57,7 +57,7 @@
 
         <dt>…between logical threads of execution…</dt>
         <dd>
-            While channels are certainly useful for coordinating between threads, they do no require actual
+            While channels are certainly useful for coordinating between threads, they do not require actual
             OS-level threads to work. They are usable within ClojureScript, which has only a single thread of
             execution. In fact, the most common use case does not require dedicated threads.
         </dd>
@@ -260,7 +260,7 @@
         <p>
             Nonetheless, this asynchronous variant would work just fine in ClojureScript. The only price we have to pay
             is a small sampling of callback hell. But what if there was a way to maintain the readability of the
-            synchronous function buy still enjoy the benefits of asynchronous operation? Well, let’s check out what
+            synchronous function but still enjoy the benefits of asynchronous operation? Well, let’s check out what
             <code>go</code> can do for us:
         </p>
 

--- a/resources/templates/tutorial/a-minimal-client.html
+++ b/resources/templates/tutorial/a-minimal-client.html
@@ -126,14 +126,14 @@
 
             <p>
                 The <code>&lt;!</code> function takes a value from the channel. This function can only be used in the
-                context context of a <code>go</code>. This will allow the loop to park until it has a value. It’s
-                nice because it allow you to write code to appear as if the code blocks at that point without actually
+                context of a <code>go</code>. This will allow the loop to park until it has a value. It’s
+                nice because it allows you to write code to appear as if the code blocks at that point without actually
                 blocking.
             </p>
 
             <p>
                 We use a <code>when-let</code> because the channel will always produce a non-null value. If we get a
-                null value, that indicates the channel was closed. This also means you can not put a null value into
+                null value, that indicates the channel was closed. This also means you cannot put a null value into
                 a channel. If there is a chance the channel will produce a <code>false</code> value, you can use
                 <code>when-some</code> instead, which was introduced in Clojure 1.6.
             </p>
@@ -166,7 +166,7 @@
                 Once you have a running event loop, there is one last thing we should probably do. We should close
                 the channel once we're done with it. This will cause the event loop we created to terminate cleanly
                 and be garbage-collected. To do this, all you need to do is call <code>close!</code> on the channel.
-                This idempotent call will cause the channel to longer accept new values, but will allow readers to
+                This idempotent call will cause the channel to no longer accept new values, but will allow readers to
                 continue reading values until the channel is exhausted.
             </p>
         </section>

--- a/resources/templates/tutorial/chat-together.html
+++ b/resources/templates/tutorial/chat-together.html
@@ -101,8 +101,8 @@
             </p>
 
             <p>
-                Now the only bit of functionality you will need to use in mult-channel properly is to ensure that when
-                the client disconnects you shut down things down properly:
+                Now the only bit of functionality you will need to use a mult-channel properly is to ensure that when
+                the client disconnects you shut things down properly:
             </p>
             <pre class="brush: clojure">(async/untap! subscribe-channel chat-events)
 (async/close! chat-events)</pre>

--- a/resources/templates/tutorial/index.html
+++ b/resources/templates/tutorial/index.html
@@ -82,8 +82,8 @@
             <ul>
                 <li>
                     All of the code related to the chat demo and tutorial is under the
-                    <code>async-workshop.chat-demo</code> namespace. The client (ClojureScript) code will be under
-                    <code>async-workshop.chat-demo.client</code>, and the server (Clojure) code will be under
+                    <code>async-workshop.chat-demo</code> namespace. The client (ClojureScript) code is under
+                    <code>async-workshop.chat-demo.client</code>, and the server (Clojure) code is under
                     <code>async-workshop.chat-demo.server</code>.
                 </li>
                 <li>

--- a/resources/templates/tutorial/sending-a-message.html
+++ b/resources/templates/tutorial/sending-a-message.html
@@ -84,7 +84,7 @@
             <pre class="brush: clojure">(om/root chat-input-widget app-state
   {:target (.getElementById js/document "chatInputWidget")})</pre>
             <p>
-                Note that in this example, the <code>chat-input-widget</code> var has ben referred.
+                Note that in this example, the <code>chat-input-widget</code> var has been referred.
             </p>
         </section>
 
@@ -113,7 +113,7 @@
             <h2>Produce the message</h2>
 
             <p>
-                Now that there is a place to put the message, let’s modify <code>send-message</code> to the job. The
+                Now that there is a place to put the message, let’s modify <code>send-message</code> to do the job. The
                 code for this is fairly straightforward. Just dereference the cursor passed in to get access to the
                 channel:
             </p>
@@ -162,7 +162,7 @@
             <h2>Summary</h2>
 
             <p>
-                In this section, we’ve primary learned how to use multiple channels together using <code>alts!</code>.
+                In this section, we’ve primarily learned how to use multiple channels together using <code>alts!</code>.
                 In the next section, we’ll start seeing how we can use this technique together with several other
                 new ones to get multiple clients actually talking to each other.
             </p>


### PR DESCRIPTION
Preparing a BREPL may take longer than the 30 second default timeout. This PR increases the timeout to 2 minutes.
